### PR TITLE
Fixed htable function

### DIFF
--- a/R/htable.R
+++ b/R/htable.R
@@ -21,7 +21,7 @@
 #' @param height The height of the table in pixels.
 #' @author Jeff Allen \email{jeff@@trestletech.com}
 #' @export
-htable <- function(outputId, clickId = NULL, readOnly = false,
+htable <- function(outputId, clickId = NULL, readOnly = 'false',
                    headers=c("enabled", "disabled", "provided"), 
                    minRows=0, minCols=0, width=0, height=0){
   


### PR DESCRIPTION
added in quotes to htable function because the examples were not working correclty without them.  Check out the conversation on the google group
https://groups.google.com/forum/#!topic/shiny-discuss/F8aAtv85ZGs
