### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can install the latest version of the code using the `devtools` R package.
 install.packages("devtools")
 
 library(devtools)
-install_github("shinyTable", "trestletech")
+install_github("trestletech/shinyTable")
 ```
 
 ## Examples


### PR DESCRIPTION
install_github( "shinyTable","trestletech") is depreciated

The proper use is :

install_github("trestletech/shinyTable")